### PR TITLE
France: add VeriSources (French OSINT guides + company/person verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ Check the - [Resources containing multi-country links](#resources-containing-mul
 - [OSINT Tools for European Countries / France](https://cyberint.uk/osint_tools/europe/#france)
 - [OSINT HUB FR](https://github.com/Anadema/OSINT-HUB-FR)
 - [OSINT-Tools-France](https://github.com/paulpogoda/OSINT-Tools-France)
+- [VeriSources - Guides OSINT FR & verification d'entreprise/personne](https://verisources.fr/guides)
 - [CNTY World](https://start.me/p/kxNv55/cnty-world)
 - [Worldwide OSINT tools map - France](https://cybdetective.com/osintmap/)
 - [OSINT Tools France](https://github.com/Provereno-Media/OSINT-Tools-France)


### PR DESCRIPTION
Bonjour, et merci pour cette liste vraiment utile organisee par pays.

J'ajoute une ressource francophone a la section France: **VeriSources** (https://verisources.fr/guides), un ensemble de guides OSINT en francais (recherche de personne, verification d'entreprise via les registres FR/BE/LU, recherche d'image inversee, detection de faux profils) plus un annuaire independant d'agences d'enquete/OSINT.

Disclosure: je suis lie au site. Je le propose car la section France ne contient pour l'instant que des listes d'outils, et aucune ressource francophone de type guides + verification d'entreprise/personne, donc cela me semble complementaire des entrees existantes (OSINT HUB FR, OSINT-Tools-France). N'hesitez pas a refuser ou ajuster le libelle si cela ne correspond pas a la ligne editoriale. Merci !